### PR TITLE
Prototype pollution (Fixed)

### DIFF
--- a/lib/nessy.js
+++ b/lib/nessy.js
@@ -14,6 +14,11 @@ module.exports = (selector, value, divider, obj) => {
     
     for (let i = 0; i < arr.length ; i++) {
         const name = arr[i];
+        if (name === '__proto__' ||
+           (name == 'prototype' && i>0 && arr[i-1] == 'constructor')
+          ) {
+            continue;
+        }
         
         if (i === arr.length - 1)
             obj[name] = value;


### PR DESCRIPTION
Hi,
This package is vulnerable to ```prototype pollution```.
```javascript
var nessy = require("nessy")
var obj = {}
console.log("Before : " + {}.polluted);
nessy('a/__proto__/polluted', "Yes! Its Polluted", '/', obj);
console.log("After : " + {}.polluted);
```
Output
```
Before : undefined
After : Yes! Its Polluted
```
Fix avoids prototype pollution.